### PR TITLE
Install IWYU into LLVM prefix

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -114,13 +114,7 @@ ubuntu_factory.addStep(ShellCommand(
 ubuntu_factory.addStep(Compile(
     name="compile IWYU", description="compiling IWYU", descriptionDone="compile IWYU",
     haltOnFailure=True,
-    command=["ninja", "-C", os.path.join(WORKSPACE_PATH, "build_iwyu/")]))
-
-ubuntu_factory.addStep(ShellCommand(
-    name="copy IWYU", description="copying IWYU", descriptionDone="copy IWYU",
-    haltOnFailure=True,
-    command=["cp", os.path.join(WORKSPACE_PATH, "build_iwyu/include-what-you-use"),
-                   os.path.join(WORKSPACE_PATH, "installed/bin/")]))
+    command=["ninja", "-C", os.path.join(WORKSPACE_PATH, "build_iwyu/"), "install"]))
 
 ubuntu_factory.addStep(ShellCommand(
     name="test IWYU", description="testing IWYU", descriptionDone="test IWYU",

--- a/provisioning_slave.sh
+++ b/provisioning_slave.sh
@@ -41,7 +41,7 @@ cd /mnt/buildbot_iwyu_trunk/workspace/sources
 git clone https://github.com/include-what-you-use/include-what-you-use.git iwyu
 mkdir /mnt/buildbot_iwyu_trunk/workspace/build_iwyu
 cd /mnt/buildbot_iwyu_trunk/workspace/build_iwyu
-cmake -G Ninja -DCMAKE_PREFIX_PATH=/mnt/buildbot_iwyu_trunk/workspace/installed/ /mnt/buildbot_iwyu_trunk/workspace/sources/iwyu/
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/mnt/buildbot_iwyu_trunk/workspace/installed/ -DCMAKE_PREFIX_PATH=/mnt/buildbot_iwyu_trunk/workspace/installed/ /mnt/buildbot_iwyu_trunk/workspace/sources/iwyu/
 
 
 # Slave startup.


### PR DESCRIPTION
This obviates the need for an explicit copy, and leaves it to IWYU's
build system to know what needs to be installed and from where.