### PR TITLE
New buildbot

### DIFF
--- a/iwyu.py
+++ b/iwyu.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-# As an example was taken EC2LatentBuildSlave https://github.com/buildbot/buildbot/blob/master/master/buildbot/buildslave/ec2.py
-
 import os
 import time
 
@@ -15,15 +13,15 @@ from twisted.internet import threads
 from twisted.python import log
 
 from buildbot import config
-from buildbot.buildslave.base import AbstractLatentBuildSlave
+from buildbot.worker import AbstractLatentWorker
 
 RUNNING = "running"
 STOPPED = "stopped"
 
-class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+class EC2LatentWorker(AbstractLatentWorker):
     """Slave which starts existing EC2 instance, executes build, stops instance.
 
-    Difference between default EC2LatentBuildSlave is it doesn't create a new
+    Difference between default EC2LatentWorker is it doesn't create a new
     instance, but starts existing.
     """
 
@@ -33,7 +31,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                  aws_id_file_path, region, instance_name):
         if not boto:
             config.error("The python module 'boto' is needed to use EC2 build slaves")
-        AbstractLatentBuildSlave.__init__(self, name, password,
+        AbstractLatentWorker.__init__(self, name, password,
             max_builds=None, notify_on_missing=[], missing_timeout=60 * 20,
             build_wait_timeout=0, properties={}, locks=None)
         if not os.path.exists(aws_id_file_path):
@@ -43,9 +41,9 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
         with open(aws_id_file_path, "r") as aws_credentials_file:
             access_key_id = aws_credentials_file.readline().strip()
             secret_key = aws_credentials_file.readline().strip()
-        self.conn = boto.ec2.connect_to_region(region,
+        self.ec2_conn = boto.ec2.connect_to_region(region,
             aws_access_key_id=access_key_id, aws_secret_access_key=secret_key)
-        self.instance = self.conn.get_only_instances(filters={"tag:Name": instance_name})[0]
+        self.instance = self.ec2_conn.get_only_instances(filters={"tag:Name": instance_name})[0]
 
     def start_instance(self, build):
         return threads.deferToThread(self._start_instance)

--- a/master.cfg
+++ b/master.cfg
@@ -17,7 +17,8 @@ c = BuildmasterConfig = {}
 import iwyu
 from buildbot.buildslave import BuildSlave
 c['slaves'] = [
-	BuildSlave("ubuntu-16.04-bot", "*masked*")
+    iwyu.EC2LatentBuildSlave("ubuntu-18.04-bot-ephemeral", "*masked*",
+        "/path/to/aws_credentials.txt", "us-west-2", "buildbot-worker-ubuntu"),
 ]
 
 # 'protocols' contains information about protocols which master will use for
@@ -56,7 +57,7 @@ from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.changes import filter
 c['schedulers'] = []
-all_builder_names = ["ubuntu-16.04-builder"]
+all_builder_names = ["ubuntu-18.04-builder"]
 c['schedulers'].append(Nightly(name="iwyu", builderNames=all_builder_names, branch=None,
     # No change_filter because changes from all pollers should trigger a build.
     hour=(4 - time.timezone / (60 * 60)) % 24, minute=0,  # 04:00 UTC == 20:00 PST
@@ -137,8 +138,8 @@ from buildbot.config import BuilderConfig
 
 c['builders'] = []
 c['builders'].append(
-    BuilderConfig(name="ubuntu-16.04-builder",
-      slavenames=["ubuntu-16.04-bot"],
+    BuilderConfig(name="ubuntu-18.04-builder",
+      slavenames=["ubuntu-18.04-bot-ephemeral"],
       factory=ubuntu_factory))
 
 ####### STATUS TARGETS

--- a/master.cfg
+++ b/master.cfg
@@ -128,6 +128,12 @@ ubuntu_factory.addStep(ShellCommand(
     haltOnFailure=True,
     command=[os.path.join(WORKSPACE_PATH, "sources/iwyu/fix_includes_test.py")]))
 
+ubuntu_factory.addStep(ShellCommand(
+    name="test iwyu_tool", description="testing iwyu_tool.py", descriptionDone="test iwyu_tool",
+    haltOnFailure=True,
+    command=[os.path.join(WORKSPACE_PATH, "sources/iwyu/iwyu_tool_test.py")]))
+
+
 from buildbot.config import BuilderConfig
 
 c['builders'] = []

--- a/master.cfg
+++ b/master.cfg
@@ -33,16 +33,13 @@ c['protocols'] = {'pb': {'port': 9989}}
 # the 'change_source' setting tells the buildmaster how it should find out
 # about source code changes.  Here we point to the buildbot clone of pyflakes.
 
-from buildbot.changes.svnpoller import SVNPoller, split_file_alwaystrunk
 from buildbot.changes.gitpoller import GitPoller
 c['change_source'] = []
-c['change_source'].append(SVNPoller(
-    svnurl="http://llvm.org/svn/llvm-project/llvm/trunk",
-    split_file=split_file_alwaystrunk,
+c['change_source'].append(GitPoller(
+    repourl="https://git.llvm.org/git/llvm.git",
     project="llvm", pollinterval=30 * 60))
-c['change_source'].append(SVNPoller(
-    svnurl="http://llvm.org/svn/llvm-project/cfe/trunk",
-    split_file=split_file_alwaystrunk,
+c['change_source'].append(GitPoller(
+    repourl="https://git.llvm.org/git/clang.git",
     project="clang", pollinterval=30 * 60))
 c['change_source'].append(GitPoller(
     repourl="https://github.com/include-what-you-use/include-what-you-use.git",
@@ -83,10 +80,12 @@ WORKSPACE_PATH = "/mnt/buildbot_iwyu_trunk/workspace"
 ubuntu_factory = BuildFactory()
 ubuntu_factory.addStep(ShellCommand(
     name="update LLVM", description="updating LLVM", descriptionDone="update LLVM",
-    command=["svn", "update", os.path.join(WORKSPACE_PATH, "sources/llvm/")]))
+    workdir=os.path.join(WORKSPACE_PATH, "sources/llvm/"),
+    command=["git", "pull"]))
 ubuntu_factory.addStep(ShellCommand(
     name="update Clang", description="updating Clang", descriptionDone="update Clang",
-    command=["svn", "update", os.path.join(WORKSPACE_PATH, "sources/llvm/tools/clang/")]))
+    workdir=os.path.join(WORKSPACE_PATH, "sources/llvm/tools/clang/"),
+    command=["git", "pull"]))
 
 ubuntu_factory.addStep(ShellCommand(
     name="clean LLVM+Clang artifacts", description="cleaning LLVM+Clang artifacts", descriptionDone="clean LLVM+Clang artifacts",

--- a/master.cfg
+++ b/master.cfg
@@ -1,6 +1,7 @@
 # -*- python -*-
-# ex: set syntax=python:
+# ex: set filetype=python:
 
+from buildbot.plugins import *
 
 # This is a sample buildmaster config file. It must be installed as
 # 'master.cfg' in your buildmaster's base directory.
@@ -9,40 +10,37 @@
 # a shorter alias to save typing.
 c = BuildmasterConfig = {}
 
-####### BUILDSLAVES
+####### WORKERS
 
-# The 'slaves' list defines the set of recognized buildslaves. Each element is
-# a BuildSlave object, specifying a unique slave name and password.  The same
-# slave name and password must be configured on the slave.
+# The 'workers' list defines the set of recognized workers. Each element is
+# a Worker object, specifying a unique worker name and password.  The same
+# worker name and password must be configured on the worker.
 import iwyu
-from buildbot.buildslave import BuildSlave
-c['slaves'] = [
-    iwyu.EC2LatentBuildSlave("ubuntu-18.04-bot-ephemeral", "*masked*",
+c['workers'] = [
+    iwyu.EC2LatentWorker("ubuntu-18_04-bot-ephemeral", "*masked*",
         "/path/to/aws_credentials.txt", "us-west-2", "buildbot-worker-ubuntu"),
 ]
 
 # 'protocols' contains information about protocols which master will use for
-# communicating with slaves.
-# You must define at least 'port' option that slaves could connect to your master
-# with this protocol.
-# 'port' must match the value configured into the buildslaves (with their
+# communicating with workers. You must define at least 'port' option that workers
+# could connect to your master with this protocol.
+# 'port' must match the value configured into the workers (with their
 # --master option)
 c['protocols'] = {'pb': {'port': 9989}}
 
 ####### CHANGESOURCES
 
 # the 'change_source' setting tells the buildmaster how it should find out
-# about source code changes.  Here we point to the buildbot clone of pyflakes.
+# about source code changes.  Here we point to the buildbot version of a python hello-world project.
 
-from buildbot.changes.gitpoller import GitPoller
 c['change_source'] = []
-c['change_source'].append(GitPoller(
+c['change_source'].append(changes.GitPoller(
     repourl="https://git.llvm.org/git/llvm.git",
     project="llvm", pollinterval=30 * 60))
-c['change_source'].append(GitPoller(
+c['change_source'].append(changes.GitPoller(
     repourl="https://git.llvm.org/git/clang.git",
     project="clang", pollinterval=30 * 60))
-c['change_source'].append(GitPoller(
+c['change_source'].append(changes.GitPoller(
     repourl="https://github.com/include-what-you-use/include-what-you-use.git",
     project="iwyu", pollinterval=30 * 60))
 
@@ -52,121 +50,99 @@ c['change_source'].append(GitPoller(
 # case, just kick off a 'runtests' build
 
 import time
-from buildbot.schedulers.basic import SingleBranchScheduler
-from buildbot.schedulers.forcesched import ForceScheduler
-from buildbot.schedulers.timed import Nightly
-from buildbot.changes import filter
+all_builder_names = ["ubuntu-18_04-builder"]
 c['schedulers'] = []
-all_builder_names = ["ubuntu-18.04-builder"]
-c['schedulers'].append(Nightly(name="iwyu", builderNames=all_builder_names, branch=None,
-    # No change_filter because changes from all pollers should trigger a build.
-    hour=(4 - time.timezone / (60 * 60)) % 24, minute=0,  # 04:00 UTC == 20:00 PST
-    onlyIfChanged=True))
-c['schedulers'].append(ForceScheduler(
+c['schedulers'].append(schedulers.Nightly(
+                            name="iwyu",
+                            builderNames=all_builder_names,
+                            # All pollers should trigger a build.
+                            change_filter=util.ChangeFilter(project=['iwyu', 'llvm', 'clang']),
+                            hour=int((4 - time.timezone / (60 * 60)) % 24),
+                            minute=0,  # 04:00 UTC == 20:00 PST
+                            onlyIfChanged=True))
+c['schedulers'].append(schedulers.ForceScheduler(
                             name="force",
                             builderNames=all_builder_names))
 
 ####### BUILDERS
 
 # The 'builders' list defines the Builders, which tell Buildbot how to perform a build:
-# what steps, and which slaves can execute them.  Note that any particular build will
-# only take place on one slave.
+# what steps, and which workers can execute them.  Note that any particular build will
+# only take place on one worker.
 
 import os
-from buildbot.process.factory import BuildFactory
-from buildbot.steps.shell import ShellCommand, Compile
-
 
 WORKSPACE_PATH = "/mnt/buildbot_iwyu_trunk/workspace"
-ubuntu_factory = BuildFactory()
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory = util.BuildFactory()
+ubuntu_factory.addStep(steps.ShellCommand(
     name="update LLVM", description="updating LLVM", descriptionDone="update LLVM",
     workdir=os.path.join(WORKSPACE_PATH, "sources/llvm/"),
     command=["git", "pull"]))
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory.addStep(steps.ShellCommand(
     name="update Clang", description="updating Clang", descriptionDone="update Clang",
     workdir=os.path.join(WORKSPACE_PATH, "sources/llvm/tools/clang/"),
     command=["git", "pull"]))
 
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory.addStep(steps.ShellCommand(
     name="clean LLVM+Clang artifacts", description="cleaning LLVM+Clang artifacts", descriptionDone="clean LLVM+Clang artifacts",
     command=["rm", "-rf", os.path.join(WORKSPACE_PATH, "installed/")]))
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory.addStep(steps.ShellCommand(
     name="clean LLVM+Clang", description="cleaning LLVM+Clang", descriptionDone="clean LLVM+Clang",
     command=["ninja", "-C", os.path.join(WORKSPACE_PATH, "build_llvm/"), "clean"]))
 
-ubuntu_factory.addStep(Compile(
+ubuntu_factory.addStep(steps.Compile(
     name="compile LLVM+Clang", description="compiling LLVM+Clang", descriptionDone="compile LLVM+Clang",
     haltOnFailure=True,
     command=["ninja", "-C", os.path.join(WORKSPACE_PATH, "build_llvm/"), "install"]))
 
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory.addStep(steps.ShellCommand(
     name="update IWYU", description="updating IWYU", descriptionDone="update IWYU",
     #haltOnFailure=True,
     workdir=os.path.join(WORKSPACE_PATH, "sources/iwyu/"),
     command=["git", "pull"]))
 
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory.addStep(steps.ShellCommand(
     name="clean IWYU", description="cleaning IWYU", descriptionDone="clean IWYU",
     haltOnFailure=True,
     command=["ninja", "-C", os.path.join(WORKSPACE_PATH, "build_iwyu/"), "clean"]))
 
-ubuntu_factory.addStep(Compile(
+ubuntu_factory.addStep(steps.Compile(
     name="compile IWYU", description="compiling IWYU", descriptionDone="compile IWYU",
     haltOnFailure=True,
     command=["ninja", "-C", os.path.join(WORKSPACE_PATH, "build_iwyu/"), "install"]))
 
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory.addStep(steps.ShellCommand(
     name="test IWYU", description="testing IWYU", descriptionDone="test IWYU",
     haltOnFailure=True,
     command=[os.path.join(WORKSPACE_PATH, "sources/iwyu/run_iwyu_tests.py")],
     workdir=os.path.join(WORKSPACE_PATH, "sources/iwyu/"),
     env={"PATH": [os.path.join(WORKSPACE_PATH, "installed/bin"), "${PATH}"]}))
 
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory.addStep(steps.ShellCommand(
     name="test fix_includes", description="testing fix_includes.py", descriptionDone="test fix_includes",
     haltOnFailure=True,
     command=[os.path.join(WORKSPACE_PATH, "sources/iwyu/fix_includes_test.py")]))
 
-ubuntu_factory.addStep(ShellCommand(
+ubuntu_factory.addStep(steps.ShellCommand(
     name="test iwyu_tool", description="testing iwyu_tool.py", descriptionDone="test iwyu_tool",
     haltOnFailure=True,
     command=[os.path.join(WORKSPACE_PATH, "sources/iwyu/iwyu_tool_test.py")]))
 
 
-from buildbot.config import BuilderConfig
-
 c['builders'] = []
 c['builders'].append(
-    BuilderConfig(name="ubuntu-18.04-builder",
-      slavenames=["ubuntu-18.04-bot-ephemeral"],
+    util.BuilderConfig(name="ubuntu-18_04-builder",
+      workernames=["ubuntu-18_04-bot-ephemeral"],
       factory=ubuntu_factory))
 
-####### STATUS TARGETS
+####### BUILDBOT SERVICES
 
-# 'status' is a list of Status Targets. The results of each build will be
-# pushed to these targets. buildbot/status/*.py has a variety to choose from,
-# including web pages, email senders, and IRC bots.
+# 'services' is a list of BuildbotService items like reporter targets. The
+# status of each build will be pushed to these targets. buildbot/reporters/*.py
+# has a variety to choose from, like IRC bots.
 
-c['status'] = []
-
-from buildbot.status import html, mail
-from buildbot.status.web import authz, auth
-
-authz_cfg=authz.Authz(
-    # change any of these to True to enable; see the manual for more
-    # options
-    auth=auth.BasicAuth([("*masked*","*masked*")]),
-    gracefulShutdown = False,
-    forceBuild = 'auth', # use this to test your slave once it is set up
-    forceAllBuilds = False,
-    pingBuilder = False,
-    stopBuild = False,
-    stopAllBuilds = False,
-    cancelPendingBuild = False,
-)
-c['status'].append(html.WebStatus(http_port=8010, authz=authz_cfg))
-c['status'].append(mail.MailNotifier(
+c['services'] = []
+c['services'].append(reporters.MailNotifier(
     fromaddr="buildbot@include-what-you-use.org",
     sendToInterestedUsers=False,
     mode=("failing",),
@@ -177,20 +153,35 @@ c['status'].append(mail.MailNotifier(
 
 ####### PROJECT IDENTITY
 
-# the 'title' string will appear at the top of this buildbot
-# installation's html.WebStatus home page (linked to the
-# 'titleURL') and is embedded in the title of the waterfall HTML page.
+# the 'title' string will appear at the top of this buildbot installation's
+# home pages (linked to the 'titleURL').
 
 c['title'] = "include-what-you-use"
-c['titleURL'] = "http://include-what-you-use.org"
+c['titleURL'] = "https://include-what-you-use.org"
 
 # the 'buildbotURL' string should point to the location where the buildbot's
-# internal web server (usually the html.WebStatus page) is visible. This
-# typically uses the port number set in the Waterfall 'status' entry, but
-# with an externally-visible host name which the buildbot cannot figure out
-# without some help.
+# internal web server is visible. This typically uses the port number set in
+# the 'www' entry below, but with an externally-visible host name which the
+# buildbot cannot figure out without some help.
 
 c['buildbotURL'] = "http://buildbot.include-what-you-use.org:8010/"
+
+# minimalistic config to activate new web UI
+c['www'] = dict(port=8010,
+                plugins=dict(waterfall_view={}, console_view={}, grid_view={}))
+authz = util.Authz(
+    allowRules=[
+        util.AnyControlEndpointMatcher(role="admins"),
+    ],
+    roleMatchers=[
+        util.RolesFromUsername(roles=["admins"], usernames=["*masked*"])
+    ]
+)
+auth=util.UserPasswordAuth({'*masked*': '*masked*'})
+c['www']['auth'] = auth
+c['www']['authz'] = authz
+
+c['buildbotNetUsageData'] = None
 
 ####### DB URL
 

--- a/master.cfg
+++ b/master.cfg
@@ -18,7 +18,8 @@ c = BuildmasterConfig = {}
 import iwyu
 c['workers'] = [
     iwyu.EC2LatentWorker("ubuntu-18_04-bot-ephemeral", "*masked*",
-        "/path/to/aws_credentials.txt", "us-west-2", "buildbot-worker-ubuntu"),
+                         "/path/to/aws_credentials.txt", "us-west-2",
+                         "buildbot-worker-ubuntu"),
 ]
 
 # 'protocols' contains information about protocols which master will use for
@@ -53,16 +54,16 @@ import time
 all_builder_names = ["ubuntu-18_04-builder"]
 c['schedulers'] = []
 c['schedulers'].append(schedulers.Nightly(
-                            name="iwyu",
-                            builderNames=all_builder_names,
-                            # All pollers should trigger a build.
-                            change_filter=util.ChangeFilter(project=['iwyu', 'llvm', 'clang']),
-                            hour=int((4 - time.timezone / (60 * 60)) % 24),
-                            minute=0,  # 04:00 UTC == 20:00 PST
-                            onlyIfChanged=True))
+    name="iwyu",
+    builderNames=all_builder_names,
+    # All pollers should trigger a build.
+    change_filter=util.ChangeFilter(project=['iwyu', 'llvm', 'clang']),
+    hour=int((4 - time.timezone / (60 * 60)) % 24),
+    minute=0,  # 04:00 UTC == 20:00 PST
+    onlyIfChanged=True))
 c['schedulers'].append(schedulers.ForceScheduler(
-                            name="force",
-                            builderNames=all_builder_names))
+    name="force",
+    builderNames=all_builder_names))
 
 ####### BUILDERS
 
@@ -78,6 +79,7 @@ ubuntu_factory.addStep(steps.ShellCommand(
     name="update LLVM", description="updating LLVM", descriptionDone="update LLVM",
     workdir=os.path.join(WORKSPACE_PATH, "sources/llvm/"),
     command=["git", "pull"]))
+
 ubuntu_factory.addStep(steps.ShellCommand(
     name="update Clang", description="updating Clang", descriptionDone="update Clang",
     workdir=os.path.join(WORKSPACE_PATH, "sources/llvm/tools/clang/"),
@@ -86,6 +88,7 @@ ubuntu_factory.addStep(steps.ShellCommand(
 ubuntu_factory.addStep(steps.ShellCommand(
     name="clean LLVM+Clang artifacts", description="cleaning LLVM+Clang artifacts", descriptionDone="clean LLVM+Clang artifacts",
     command=["rm", "-rf", os.path.join(WORKSPACE_PATH, "installed/")]))
+
 ubuntu_factory.addStep(steps.ShellCommand(
     name="clean LLVM+Clang", description="cleaning LLVM+Clang", descriptionDone="clean LLVM+Clang",
     command=["ninja", "-C", os.path.join(WORKSPACE_PATH, "build_llvm/"), "clean"]))
@@ -97,7 +100,6 @@ ubuntu_factory.addStep(steps.Compile(
 
 ubuntu_factory.addStep(steps.ShellCommand(
     name="update IWYU", description="updating IWYU", descriptionDone="update IWYU",
-    #haltOnFailure=True,
     workdir=os.path.join(WORKSPACE_PATH, "sources/iwyu/"),
     command=["git", "pull"]))
 
@@ -132,8 +134,8 @@ ubuntu_factory.addStep(steps.ShellCommand(
 c['builders'] = []
 c['builders'].append(
     util.BuilderConfig(name="ubuntu-18_04-builder",
-      workernames=["ubuntu-18_04-bot-ephemeral"],
-      factory=ubuntu_factory))
+                       workernames=["ubuntu-18_04-bot-ephemeral"],
+                       factory=ubuntu_factory))
 
 ####### BUILDBOT SERVICES
 
@@ -177,7 +179,7 @@ authz = util.Authz(
         util.RolesFromUsername(roles=["admins"], usernames=["*masked*"])
     ]
 )
-auth=util.UserPasswordAuth({'*masked*': '*masked*'})
+auth = util.UserPasswordAuth({'*masked*': '*masked*'})
 c['www']['auth'] = auth
 c['www']['authz'] = authz
 
@@ -188,5 +190,5 @@ c['buildbotNetUsageData'] = None
 c['db'] = {
     # This specifies what database buildbot uses to store its state.  You can leave
     # this at its default for all but the largest installations.
-    'db_url' : "sqlite:///state.sqlite",
+    'db_url': "sqlite:///state.sqlite",
 }

--- a/provisioning_slave.sh
+++ b/provisioning_slave.sh
@@ -4,6 +4,7 @@ sudo apt-get update
 sudo apt-get install -y subversion git
 sudo apt-get install -y build-essential ncurses-dev libz-dev
 sudo apt-get install -y cmake
+sudo apt-get install -y python python-pip
 
 # Install ninja.
 git clone git://github.com/martine/ninja.git ~/ninja
@@ -12,8 +13,7 @@ cd ~/ninja
 sudo cp ./ninja /usr/bin/ninja
 
 # Install buildbot slave.
-sudo apt-get install -y python-dev python-setuptools
-sudo easy_install buildbot-slave
+sudo pip install buildbot-slave
 buildslave create-slave slave buildbot-master.include-what-you-use.org:9989 <name> <password>
 
 

--- a/provisioning_slave.sh
+++ b/provisioning_slave.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get install -y subversion git
+sudo apt-get install -y git
 sudo apt-get install -y build-essential ncurses-dev libz-dev
 sudo apt-get install -y cmake
 sudo apt-get install -y python python-pip
@@ -27,8 +27,9 @@ sudo chown ubuntu:ubuntu /mnt/buildbot_iwyu_trunk/workspace/
 # UUID=224413c7-7291-4fcb-a247-7e2ce78ce1f4 /mnt/buildbot_iwyu_trunk auto defaults,errors=remount-ro 0 2
 
 mkdir /mnt/buildbot_iwyu_trunk/workspace/sources
-svn checkout http://llvm.org/svn/llvm-project/llvm/trunk /mnt/buildbot_iwyu_trunk/workspace/sources/llvm
-svn checkout http://llvm.org/svn/llvm-project/cfe/trunk /mnt/buildbot_iwyu_trunk/workspace/sources/llvm/tools/clang
+cd /mnt/buildbot_iwyu_trunk/workspace/sources
+git clone --depth 1 https://git.llvm.org/git/llvm.git llvm
+git clone --depth 1 https://git.llvm.org/git/clang.git llvm/tools/clang
 
 mkdir /mnt/buildbot_iwyu_trunk/workspace/build_llvm
 cd /mnt/buildbot_iwyu_trunk/workspace/build_llvm
@@ -37,7 +38,6 @@ ninja install
 
 
 cd /mnt/buildbot_iwyu_trunk/workspace/sources
-#svn checkout https://include-what-you-use.googlecode.com/svn/trunk iwyu
 git clone https://github.com/include-what-you-use/include-what-you-use.git iwyu
 mkdir /mnt/buildbot_iwyu_trunk/workspace/build_iwyu
 cd /mnt/buildbot_iwyu_trunk/workspace/build_iwyu

--- a/provisioning_worker.sh
+++ b/provisioning_worker.sh
@@ -12,9 +12,9 @@ cd ~/ninja
 ./configure.py --bootstrap
 sudo cp ./ninja /usr/bin/ninja
 
-# Install buildbot slave.
-sudo pip install buildbot-slave
-buildslave create-slave slave buildbot-master.include-what-you-use.org:9989 <name> <password>
+# Install buildbot worker.
+sudo pip install buildbot-worker
+buildbot-worker create-worker worker buildbot-master.include-what-you-use.org:9989 <name> <password>
 
 
 # Setup EBS.
@@ -44,6 +44,6 @@ cd /mnt/buildbot_iwyu_trunk/workspace/build_iwyu
 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/mnt/buildbot_iwyu_trunk/workspace/installed/ -DCMAKE_PREFIX_PATH=/mnt/buildbot_iwyu_trunk/workspace/installed/ /mnt/buildbot_iwyu_trunk/workspace/sources/iwyu/
 
 
-# Slave startup.
+# Worker startup.
 sudo crontab -e
-  @reboot /usr/local/bin/buildslave start /home/ubuntu/slave/
+  @reboot /usr/local/bin/buildbot-worker start /home/ubuntu/worker/


### PR DESCRIPTION
This PR cleans up the build infra along a number of dimensions:

- Upgrade builder to Ubuntu 18.04
- Upgrade buildbot to latest (1.7.0)
- Use Git instead of Subversion across the board
- Use more modern Python machinery for install

This appears to have fixed the recent surge of buildbot failures due to OOM.